### PR TITLE
[FEAT] 최근 읽었던 책 목록 조회 API 구현

### DIFF
--- a/src/main/java/com/brunch/server/author/entity/Author.java
+++ b/src/main/java/com/brunch/server/author/entity/Author.java
@@ -1,8 +1,12 @@
 package com.brunch.server.author.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor
 public class Author {
 
     @Id

--- a/src/main/java/com/brunch/server/author/exeception/AuthorException.java
+++ b/src/main/java/com/brunch/server/author/exeception/AuthorException.java
@@ -1,0 +1,15 @@
+package com.brunch.server.author.exeception;
+
+import com.brunch.server.author.message.ErrorMessage;
+import lombok.Getter;
+
+@Getter
+public class AuthorException extends RuntimeException {
+
+    private final ErrorMessage errorMessage;
+
+    public AuthorException(ErrorMessage errorMessage) {
+        super("[AuthorException] : " + errorMessage.getMessage());
+        this.errorMessage = errorMessage;
+    }
+}

--- a/src/main/java/com/brunch/server/author/message/ErrorMessage.java
+++ b/src/main/java/com/brunch/server/author/message/ErrorMessage.java
@@ -2,9 +2,18 @@ package com.brunch.server.author.message;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Getter
 @AllArgsConstructor
 public enum ErrorMessage {
+
+    INVALID_AUTHOR_ID(NOT_FOUND, "유효하지 않은 작가 id입니다."),
+    ;
+
+    private final HttpStatus httpStatus;
+    private final String message;
 
 }

--- a/src/main/java/com/brunch/server/book/controller/BookController.java
+++ b/src/main/java/com/brunch/server/book/controller/BookController.java
@@ -1,11 +1,30 @@
 package com.brunch.server.book.controller;
 
+import com.brunch.server.book.message.SuccessMessage;
+import com.brunch.server.book.service.BookService;
+import com.brunch.server.book.service.dto.BookOverviewResponse;
+import com.brunch.server.book.service.dto.RecentLikedResponse;
+import com.brunch.server.common.dto.SuccessResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("api/v1/books")
+@RequestMapping("api/v1")
 public class BookController {
+
+    private final BookService bookService;
+
+    // 최근 읽었던 책 목록 조회
+    @GetMapping("/books")
+    public SuccessResponse<RecentLikedResponse> getRecentAndLikedBooks(){
+        RecentLikedResponse recentLikedResponse = bookService.getRecentAndLikedBooks();
+        return SuccessResponse.success(SuccessMessage.SUCCESS_GET_VIEWED_BOOKS.getMessage(), recentLikedResponse);
+    }
+
 }

--- a/src/main/java/com/brunch/server/book/entity/Book.java
+++ b/src/main/java/com/brunch/server/book/entity/Book.java
@@ -3,6 +3,7 @@ package com.brunch.server.book.entity;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -27,5 +28,8 @@ public class Book {
     private int progress;
     private int likeCount;
     private String tag;
+
+    @Column(name = "last_viewed")
+    private LocalDateTime lastViewed;
 
 }

--- a/src/main/java/com/brunch/server/book/entity/Book.java
+++ b/src/main/java/com/brunch/server/book/entity/Book.java
@@ -1,8 +1,12 @@
 package com.brunch.server.book.entity;
 
 import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
+@Getter
+@NoArgsConstructor
 public class Book {
 
     @Id
@@ -10,7 +14,8 @@ public class Book {
     @Column(name = "book_id")
     private Long id;
 
-    private long author_id;
+    @Column(name = "author_id")
+    private long authorId;
 
     private String title;
     private int episode;

--- a/src/main/java/com/brunch/server/book/message/ErrorMessage.java
+++ b/src/main/java/com/brunch/server/book/message/ErrorMessage.java
@@ -12,6 +12,7 @@ public enum ErrorMessage {
 
     /* 404 NOT_FOUND : 자원을 찾을 수 없음 */
     INVALID_BOOK(NOT_FOUND, "유효하지 않은 책입니다."),
+    INVALID_AUTHOR_ID(NOT_FOUND, "유효하지 않은 작가 id입니다."),
     ;
 
     private final HttpStatus httpStatus;

--- a/src/main/java/com/brunch/server/book/message/SuccessMessage.java
+++ b/src/main/java/com/brunch/server/book/message/SuccessMessage.java
@@ -6,4 +6,10 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum SuccessMessage {
+
+    SUCCESS_GET_VIEWED_BOOKS("최근 읽었던 책 목록 조회 성공"),
+    SUCCESS_GET_DETAILED_BOOKS("책 상세 조회 성공"),
+    ;
+
+    private final String message;
 }

--- a/src/main/java/com/brunch/server/book/repository/BookRepository.java
+++ b/src/main/java/com/brunch/server/book/repository/BookRepository.java
@@ -2,6 +2,14 @@ package com.brunch.server.book.repository;
 
 import com.brunch.server.book.entity.Book;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
+    @Query("SELECT b FROM Book b JOIN Author a ON b.author_id = a.id ORDER BY b.id DESC")
+    List<Book> findRecentBooks();
+
+    @Query("SELECT b from Book b JOIN Author a ON b.author_id = a.id ORDER BY b.likeCount DESC")
+    List<Book> findLikedBooks();
 }

--- a/src/main/java/com/brunch/server/book/repository/BookRepository.java
+++ b/src/main/java/com/brunch/server/book/repository/BookRepository.java
@@ -1,7 +1,6 @@
 package com.brunch.server.book.repository;
 
 import com.brunch.server.book.entity.Book;
-import com.brunch.server.author.entity.Author;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 

--- a/src/main/java/com/brunch/server/book/repository/BookRepository.java
+++ b/src/main/java/com/brunch/server/book/repository/BookRepository.java
@@ -1,15 +1,18 @@
 package com.brunch.server.book.repository;
 
 import com.brunch.server.book.entity.Book;
+import com.brunch.server.author.entity.Author;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 
 public interface BookRepository extends JpaRepository<Book, Long> {
-    @Query("SELECT b FROM Book b JOIN Author a ON b.author_id = a.id ORDER BY b.id DESC")
+    @Query("SELECT b FROM Book b JOIN Author a ON b.authorId = a.id " +
+            "WHERE b.lastViewed IS NOT NULL ORDER BY b.lastViewed ASC")
     List<Book> findRecentBooks();
 
-    @Query("SELECT b from Book b JOIN Author a ON b.author_id = a.id ORDER BY b.likeCount DESC")
+    @Query("SELECT b from Book b JOIN Author a ON b.authorId = a.id " +
+            "WHERE b.likeCount IS NOT NULL ORDER BY b.lastViewed ASC")
     List<Book> findLikedBooks();
 }

--- a/src/main/java/com/brunch/server/book/service/BookService.java
+++ b/src/main/java/com/brunch/server/book/service/BookService.java
@@ -1,11 +1,72 @@
 package com.brunch.server.book.service;
 
+import com.brunch.server.author.entity.Author;
+import com.brunch.server.author.exeception.AuthorException;
+import com.brunch.server.author.message.ErrorMessage;
+import com.brunch.server.author.repository.AuthorRepository;
+import com.brunch.server.book.entity.Book;
+import com.brunch.server.book.repository.BookRepository;
+import com.brunch.server.book.service.dto.LikedBookResponse;
+import com.brunch.server.book.service.dto.RecentBookResponse;
+import com.brunch.server.book.service.dto.RecentLikedResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class BookService {
+
+    @Autowired
+    private BookRepository bookRepository;
+
+    @Autowired
+    private AuthorRepository authorRepository;
+
+    public RecentLikedResponse getRecentAndLikedBooks() {
+
+        List<Book> recentBooks = bookRepository.findRecentBooks();
+        List<Book> likedBooks = bookRepository.findLikedBooks();
+
+        List<RecentBookResponse> recentBookResponses = recentBooks.stream().map(book -> {
+
+            // Author Entity 조회
+            Author author = authorRepository.findById(book.getAuthorId())
+                    .orElseThrow(() -> new AuthorException(ErrorMessage.INVALID_AUTHOR_ID));
+
+            return new RecentBookResponse(
+                    book.getId(),
+                    book.getTitle(),
+                    author.getName(),
+                    book.getBookImage(),
+                    book.getDescription(),
+                    book.getEpisode(),
+                    book.getRequiredTime(),
+                    book.getProgress()
+
+            );
+        }).collect(Collectors.toList());
+
+        List<LikedBookResponse> likedBookResponses = likedBooks.stream().map(book -> {
+
+            // Author Entity 조회
+            Author author = authorRepository.findById(book.getAuthorId())
+                    .orElseThrow(() -> new AuthorException(ErrorMessage.INVALID_AUTHOR_ID));
+
+            return new LikedBookResponse(
+                    book.getId(),
+                    book.getTitle(),
+                    author.getName(),
+                    book.getBookImage()
+            );
+        }).collect(Collectors.toList());
+
+        return new RecentLikedResponse(recentBookResponses, likedBookResponses);
+    }
+
 }

--- a/src/main/java/com/brunch/server/book/service/BookService.java
+++ b/src/main/java/com/brunch/server/book/service/BookService.java
@@ -47,7 +47,8 @@ public class BookService {
                     book.getDescription(),
                     book.getEpisode(),
                     book.getRequiredTime(),
-                    book.getProgress()
+                    book.getProgress(),
+                    book.getLastViewed()
 
             );
         }).collect(Collectors.toList());

--- a/src/main/java/com/brunch/server/book/service/dto/LikedBookResponse.java
+++ b/src/main/java/com/brunch/server/book/service/dto/LikedBookResponse.java
@@ -1,0 +1,9 @@
+package com.brunch.server.book.service.dto;
+
+public record LikedBookResponse(
+        Long id,
+        String title,
+        String authorName,
+        String bookImage
+) {
+}

--- a/src/main/java/com/brunch/server/book/service/dto/LikedBookResponse.java
+++ b/src/main/java/com/brunch/server/book/service/dto/LikedBookResponse.java
@@ -1,9 +1,22 @@
 package com.brunch.server.book.service.dto;
 
+import com.brunch.server.author.entity.Author;
+import com.brunch.server.book.entity.Book;
+import lombok.Builder;
+
+@Builder
 public record LikedBookResponse(
         Long id,
         String title,
         String authorName,
         String bookImage
 ) {
+    public static LikedBookResponse from(Book book, Author author) {
+        return LikedBookResponse.builder()
+                .id(book.getId())
+                .title(book.getTitle())
+                .authorName(author.getName())
+                .bookImage(book.getBookImage())
+                .build();
+    }
 }

--- a/src/main/java/com/brunch/server/book/service/dto/RecentBookResponse.java
+++ b/src/main/java/com/brunch/server/book/service/dto/RecentBookResponse.java
@@ -1,0 +1,16 @@
+package com.brunch.server.book.service.dto;
+
+import java.time.LocalDateTime;
+
+public record RecentBookResponse(
+        Long id,
+        String title,
+        String authorName,
+        String bookImage,
+        String description,
+        int episode,
+        int requiredTime,
+        int progress,
+        LocalDateTime lastViewd
+) {
+}

--- a/src/main/java/com/brunch/server/book/service/dto/RecentBookResponse.java
+++ b/src/main/java/com/brunch/server/book/service/dto/RecentBookResponse.java
@@ -1,7 +1,12 @@
 package com.brunch.server.book.service.dto;
 
+import com.brunch.server.author.entity.Author;
+import com.brunch.server.book.entity.Book;
+import lombok.Builder;
+
 import java.time.LocalDateTime;
 
+@Builder
 public record RecentBookResponse(
         Long id,
         String title,
@@ -11,6 +16,19 @@ public record RecentBookResponse(
         int episode,
         int requiredTime,
         int progress,
-        LocalDateTime lastViewd
+        LocalDateTime lastViewed
 ) {
+    public static RecentBookResponse from(Book book, Author author) {
+        return RecentBookResponse.builder()
+                .id(book.getId())
+                .title(book.getTitle())
+                .authorName(author.getName())
+                .bookImage(book.getBookImage())
+                .description(book.getDescription())
+                .episode(book.getEpisode())
+                .requiredTime(book.getRequiredTime())
+                .progress(book.getProgress())
+                .lastViewed(book.getLastViewed())
+                .build();
+    }
 }

--- a/src/main/java/com/brunch/server/book/service/dto/RecentLikedResponse.java
+++ b/src/main/java/com/brunch/server/book/service/dto/RecentLikedResponse.java
@@ -1,0 +1,9 @@
+package com.brunch.server.book.service.dto;
+
+import java.util.List;
+
+public record RecentLikedResponse (
+        List<RecentBookResponse> recentBooks,
+        List<LikedBookResponse> likeBooks
+){
+}

--- a/src/main/java/com/brunch/server/book/service/dto/RecentLikedResponse.java
+++ b/src/main/java/com/brunch/server/book/service/dto/RecentLikedResponse.java
@@ -1,9 +1,12 @@
 package com.brunch.server.book.service.dto;
 
+import lombok.Builder;
+
 import java.util.List;
 
+@Builder
 public record RecentLikedResponse (
         List<RecentBookResponse> recentBooks,
-        List<LikedBookResponse> likeBooks
+        List<LikedBookResponse> likedBooks
 ){
 }


### PR DESCRIPTION
## 👀 무엇을 구현했나요?

closed : #4 
최근 읽었던 책 목록을 조회하는 API를 구현했습니다.

## 주요 코드 설명

### Book.java

https://github.com/NOWSOPT-CDSP-WEB-1/Brunch-Web-Server/blob/fd0688405dae918245c598edc6d19b890e91bcab/src/main/java/com/brunch/server/book/entity/Book.java#L18-L19

이름을 통일하기 위해 author_id에서 authorId로 변경했습니다.

https://github.com/NOWSOPT-CDSP-WEB-1/Brunch-Web-Server/blob/eb0334c8d760c5dad0a927422a171f73c1fffc48/src/main/java/com/brunch/server/book/entity/Book.java#L32-L33

최근 조회한 책 목록인데, 최근 조회한 시간을 고려하지 않았길래, last_viewed 컬럼을 추가하고 기능을 구현했습니다.

### BookRepository.java

https://github.com/NOWSOPT-CDSP-WEB-1/Brunch-Web-Server/blob/eb0334c8d760c5dad0a927422a171f73c1fffc48/src/main/java/com/brunch/server/book/repository/BookRepository.java#L10-L18

recentbook의 경우에는 최근 읽은 시간 순으로 정렬하도록 했고,
likedbook의 경우에는 현재 구현된 기능 기준으로는 좋아요 누른 책이 최근 읽은 책일거라는 생각을 바탕으로 최근 읽은 시간 순으로 정렬하도록 했지만, 좋아요 기능을 구현하면서 이 부분을 수정하면 좋을 것 같다고 생각했습니다.

### BookService.java

https://github.com/NOWSOPT-CDSP-WEB-1/Brunch-Web-Server/blob/eb0334c8d760c5dad0a927422a171f73c1fffc48/src/main/java/com/brunch/server/book/service/BookService.java#L23-L73

## test
<img width="1071" alt="스크린샷 2024-05-16 오전 3 36 12" src="https://github.com/NOWSOPT-CDSP-WEB-1/Brunch-Web-Server/assets/84909012/cdf76585-fc64-4c44-a50f-8a86f7b550f1">
