### PR TITLE
[FIX] 요일별 글 목록 조회 api

### DIFF
--- a/src/main/java/com/brunch/server/posting/dto/response/SerializedPostingsResponse.java
+++ b/src/main/java/com/brunch/server/posting/dto/response/SerializedPostingsResponse.java
@@ -8,12 +8,17 @@ import static lombok.AccessLevel.PRIVATE;
 
 @Builder(access = PRIVATE)
 public record SerializedPostingsResponse(
-        @NonNull List<SerializedPostingResponse> serializedPostings
+        @NonNull List<SerializedPostingResponse> recentPostings,
+        @NonNull List<SerializedPostingResponse> likePostings
 ) {
 
-    public static SerializedPostingsResponse of(List<SerializedPostingResponse> serializedPostings) {
+    public static SerializedPostingsResponse of(
+            List<SerializedPostingResponse> recentPostings,
+            List<SerializedPostingResponse> likePostings
+    ) {
         return SerializedPostingsResponse.builder()
-                .serializedPostings(serializedPostings)
+                .recentPostings(recentPostings)
+                .likePostings(likePostings)
                 .build();
     }
 }

--- a/src/main/java/com/brunch/server/posting/repository/PostingRepository.java
+++ b/src/main/java/com/brunch/server/posting/repository/PostingRepository.java
@@ -12,5 +12,6 @@ public interface PostingRepository extends JpaRepository<Posting, Long> {
 
     List<Posting> findAllByIsLiked(int isLiked);
 
-    List<Posting> findAllByDay(String day);
+    List<Posting> findAllByDayOrderByRequiredTimeDesc(String day);
+    List<Posting> findAllByDayOrderByLikeCountDesc(String day);
 }

--- a/src/main/java/com/brunch/server/posting/service/PostingService.java
+++ b/src/main/java/com/brunch/server/posting/service/PostingService.java
@@ -33,8 +33,9 @@ public class PostingService {
     }
 
     public SerializedPostingsResponse getSerializedPosting(String day) {
-        val serializedPostings = getSerializedPostingResponse(day);
-        return SerializedPostingsResponse.of(serializedPostings);
+        val serializedRecentPostings = getSerializedRecentPostingResponse(day);
+        val serializedLikePostings = getSerializedLikePostingResponse(day);
+        return SerializedPostingsResponse.of(serializedRecentPostings, serializedLikePostings);
     }
 
     private List<PostingResponse> getLatestViewedPostingResponse() {
@@ -56,8 +57,15 @@ public class PostingService {
         return PostingResponse.of(posting, author);
     }
 
-    private List<SerializedPostingResponse> getSerializedPostingResponse(String day) {
-        val serializedPostings = postingRepository.findAllByDay(day);
+    private List<SerializedPostingResponse> getSerializedRecentPostingResponse(String day) {
+        val serializedPostings = postingRepository.findAllByDayOrderByRequiredTimeDesc(day);
+        return serializedPostings.stream()
+                .map(this::getSerializedPostingResponse)
+                .toList();
+    }
+
+    private List<SerializedPostingResponse> getSerializedLikePostingResponse(String day) {
+        val serializedPostings = postingRepository.findAllByDayOrderByLikeCountDesc(day);
         return serializedPostings.stream()
                 .map(this::getSerializedPostingResponse)
                 .toList();


### PR DESCRIPTION
## ✨ Related Issue
- close #20 
  <br/>

## 📝 기능 구현 명세
![image](https://github.com/NOWSOPT-CDSP-WEB-1/Brunch-Web-Server/assets/81404890/a2ea40fe-319e-4c5a-a1aa-23be16d9686e)
- 요일별 연재 글 조회 api


## 🐥 추가적인 언급 사항
- 급해서 일단 강제 머지하겠습니다.